### PR TITLE
Experimental datepicker example

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,17 @@ require('./main.css');
 require('jquery-ui/themes/base/core.css');
 require('jquery-ui/themes/base/menu.css');
 require('jquery-ui/themes/base/autocomplete.css');
+require('jquery-ui/themes/base/calendar.css');
+require('jquery-ui/themes/base/datepicker.css');
 require('jquery-ui/themes/base/theme.css');
 var $ = require('jquery');
-var autocomplete = require('jquery-ui/ui/widgets/autocomplete');
+var Autocomplete = require('jquery-ui/ui/widgets/autocomplete');
+var Datepicker = require('jquery-ui/ui/widgets/datepicker');
 
 $('<h1>Welcome to the programming languages quiz</h1>').appendTo('body');
-new autocomplete({
+new Autocomplete({
   source: ['javascript', 'css', 'c', 'objectivec']
 }).element.appendTo('body').focus();
+
+$('<h2>When do you want to start the quiz?</h2>').appendTo('body');
+new Datepicker({}).element.appendTo('body');

--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
   "author": "Jörn Zaefferer",
   "license": "MIT",
   "dependencies": {
+    "cldr-data": "^30.0.1",
+    "globalize": "^1.1.2",
     "jquery": "^2.1.4",
-    "jquery-ui": "1.12.x"
+    "jquery-ui": "github:jquery/jquery-ui#datepicker"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.3",
+    "globalize-webpack-plugin": "^0.3.6",
     "css-loader": "^0.16.0",
     "extract-text-webpack-plugin": "^0.8.2",
     "file-loader": "^0.8.4",

--- a/webpack-config.js
+++ b/webpack-config.js
@@ -1,6 +1,7 @@
 var Clean = require('clean-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var GlobalizePlugin = require('globalize-webpack-plugin');
 
 module.exports = {
 	entry: {
@@ -25,6 +26,13 @@ module.exports = {
 	plugins: [
 		new Clean(['dist']),
 		new ExtractTextPlugin("app.[hash].css"),
+		new GlobalizePlugin({
+			// toggle this for actual production builds
+			production: false,
+			developmentLocale: "de",
+			supportedLocales: [ "de" ],
+			output: "globalize-compiled-data-[locale].[hash].js"
+		}),
 		new HtmlWebpackPlugin({
 			title: 'jQuery UI Autocomplete demo, built with webpack'
 		})

--- a/webpack-config.js
+++ b/webpack-config.js
@@ -11,6 +11,10 @@ module.exports = {
 		path: './dist',
 		filename: 'app.[hash].js'
 	},
+	externals: {
+		'globalize-locales': 'var {}',
+		'globalize/date': 'var {}'
+	},
 	module: {
 		loaders: [
 			{


### PR DESCRIPTION
This is adding the datepicker rewrite, in its current state, to the demo, using the globalize-webpack-plugin. Currently this doesn't work, since datepicker.js and calendar.js specify two dependencies that can't be resolved, `globalize/date` and `globalize-locales`. To reproduce locally, check out this branch, run `npm install` and `npm start`:
```
ERROR in ./~/jquery-ui/ui/widgets/datepicker.js
Module not found: Error: Cannot resolve module 'globalize/date' in /[...]/webpack-jquery-ui/node_modules/jquery-ui/ui/widgets
 @ ./~/jquery-ui/ui/widgets/datepicker.js 24:2-33:14

ERROR in ./~/jquery-ui/ui/widgets/calendar.js
Module not found: Error: Cannot resolve module 'globalize/date' in /[...]/webpack-jquery-ui/node_modules/jquery-ui/ui/widgets
 @ ./~/jquery-ui/ui/widgets/calendar.js 23:2-36:14

ERROR in ./~/jquery-ui/ui/widgets/calendar.js
Module not found: Error: Cannot resolve module 'globalize-locales' in /[...]/webpack-jquery-ui/node_modules/jquery-ui/ui/widgets
 @ ./~/jquery-ui/ui/widgets/calendar.js 23:2-36:14
```

I looked at [the mappings for these in jQuery UI's `bootstrap.js`](https://github.com/jquery/jquery-ui/blob/datepicker/demos/bootstrap.js#L85-L92), but couldn't figure out how these would/should work in the context of a webpack app.

Ping @rxaviers @fnagel @scottgonzalez - any input on this?