### PR TITLE
Add production flag to datepicker/webpack setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server --config webpack-config.js",
-    "build": "webpack --config webpack-config.js"
+    "build": "webpack --production --config webpack-config.js"
   },
   "keywords": [
     "jquery-ui",
@@ -25,11 +25,12 @@
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.3",
-    "globalize-webpack-plugin": "^0.3.6",
     "css-loader": "^0.16.0",
     "extract-text-webpack-plugin": "^0.8.2",
     "file-loader": "^0.8.4",
+    "globalize-webpack-plugin": "^0.3.6",
     "html-webpack-plugin": "^1.6.1",
+    "nopt": "^3.0.6",
     "style-loader": "^0.12.3",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.11.0"

--- a/webpack-config.js
+++ b/webpack-config.js
@@ -1,15 +1,33 @@
+var webpack = require( "webpack" );
 var Clean = require('clean-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var CommonsChunkPlugin = require( 'webpack/lib/optimize/CommonsChunkPlugin' );
 var GlobalizePlugin = require('globalize-webpack-plugin');
+var nopt = require( "nopt" );
+
+var options = nopt({
+	production: Boolean
+});
 
 module.exports = {
-	entry: {
-		main: './index.js'
-	},
+	entry: options.production ?  {
+		main: './index.js',
+		vendor: [
+			'globalize',
+			'globalize/dist/globalize-runtime/number',
+			'globalize/dist/globalize-runtime/currency',
+			'globalize/dist/globalize-runtime/date',
+			'globalize/dist/globalize-runtime/message',
+			'globalize/dist/globalize-runtime/plural',
+			'globalize/dist/globalize-runtime/relative-time',
+			'globalize/dist/globalize-runtime/unit'
+		]
+	} : "./index.js",
+	debug: !options.production,
 	output: {
 		path: './dist',
-		filename: 'app.[hash].js'
+		filename: options.production ? 'app.[hash].js' : 'app.js'
 	},
 	externals: {
 		'globalize-locales': 'var {}',
@@ -19,7 +37,7 @@ module.exports = {
 		loaders: [
 			{
 				test: /\.css$/,
-				loader: ExtractTextPlugin.extract("style-loader", "css-loader")
+				loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
 			},
 			{
 				test: /\.(jpg|png)$/,
@@ -29,16 +47,24 @@ module.exports = {
 	},
 	plugins: [
 		new Clean(['dist']),
-		new ExtractTextPlugin("app.[hash].css"),
+		new ExtractTextPlugin('app.[hash].css'),
 		new GlobalizePlugin({
-			// toggle this for actual production builds
-			production: false,
-			developmentLocale: "de",
-			supportedLocales: [ "de" ],
-			output: "globalize-compiled-data-[locale].[hash].js"
+			production: options.production,
+			developmentLocale: 'de',
+			supportedLocales: [ 'de' ],
+			output: 'globalize-compiled-data-[locale].[hash].js'
 		}),
 		new HtmlWebpackPlugin({
+			production: options.production,
 			title: 'jQuery UI Autocomplete demo, built with webpack'
 		})
-	]
+	].concat( options.production ? [
+		new webpack.optimize.DedupePlugin(),
+		new CommonsChunkPlugin( "vendor", "vendor.[hash].js" ),
+		new webpack.optimize.UglifyJsPlugin({
+			compress: {
+				warnings: false
+			}
+		})
+	] : [] )
 };


### PR DESCRIPTION
@rxaviers this builds on top of my other PR (#3), and while `npm start` still has the same issue as described there, now `npm run build` fails with this: https://gist.github.com/jzaefferer/25bfbc582b1e4d9dad81cd6c20d04c94

Maybe it fails because the globalize usage is inside node_modules, not in the app itself?